### PR TITLE
Update typings to allow additional DocumentNode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 import { DocumentNode } from 'graphql';
 
 export function loader(path: string): DocumentNode;
-export function gql(taggedTemplateLiteral: TemplateStringsArray): DocumentNode;
+export function gql(taggedTemplateLiteral: TemplateStringsArray, ...nodes: DocumentNode[]): DocumentNode;


### PR DESCRIPTION
This is to cover documents like following. The actual code supports it, but it gives annoying errors in TypeScript.

```js
const MyQuery = gql`
  query {
    foo {
      ...Baz
    }
  }
  ${BazFragment}
`
```